### PR TITLE
Add initial check to see if the chip is supported and when not using id, use default project based on chip.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,7 +405,7 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 [[package]]
 name = "espflash"
 version = "1.5.2-dev"
-source = "git+https://github.com/esp-rs/espflash?branch=bugfix/chip-name-esptool#d9ad0b62eca229e8fcfbbd1297804f7e8c89baa9"
+source = "git+https://github.com/esp-rs/espflash?branch=bugfix/chip-name-esptool#407cab46132beaec60124b7002d4c48300d020dd"
 dependencies = [
  "binread",
  "bytemuck",
@@ -896,9 +896,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+checksum = "7b10983b38c53aebdf33f542c6275b0f58a238129d00c4ae0e6fb59738d783ca"
 
 [[package]]
 name = "opener"

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,7 +84,8 @@ async fn wokwi_task(
         project_id,
         PORT
     );
-    opts.host.as_ref().map(|h| url.push_str(&format!("&_host={}",h)));
+
+    if let Some(h) = opts.host.as_ref() { url.push_str(&format!("&_host={}",h)) }
 
     println!(
         "Open the following link in the browser\r\n\r\n{}\r\n\r\n",
@@ -236,7 +237,7 @@ async fn handle_gdb_client(
         buffer.advance(n);
         let bytes = bytes.get_mut();
 
-        if bytes.len() == 0 {
+        if bytes.is_empty() {
             anyhow::bail!("GDB End of stream");
         }
 
@@ -246,8 +247,8 @@ async fn handle_gdb_client(
             bytes.advance(1);
         }
         let raw_command = String::from_utf8_lossy(bytes);
-        let start = raw_command.find("$").map(|i| i + 1); // we want everything after the $
-        let end = raw_command.find("#");
+        let start = raw_command.find('$').map(|i| i + 1); // we want everything after the $
+        let end = raw_command.find('#');
 
         match (start, end) {
             (Some(start), Some(end)) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,10 @@ struct Args {
 async fn main() -> Result<()> {
     let opts = Args::parse();
 
+    if opts.chip != Chip::Esp32 && opts.chip != Chip::Esp32c3 && opts.chip != Chip::Esp32s2 {
+        anyhow::bail!("Chip not supported in Wokwi. See available chips and features at https://docs.wokwi.com/guides/esp32#simulation-features");
+    }
+
     let (wsend, wrecv) = tokio::sync::mpsc::channel(1);
     let (gsend, grecv) = tokio::sync::mpsc::channel(1);
 
@@ -74,7 +78,7 @@ async fn wokwi_task(
                 Chip::Esp32 => "331362827438654036".to_string(),
                 Chip::Esp32s2 => "332188085821375060".to_string(),
                 Chip::Esp32c3 => "332188235906155092".to_string(),
-                _ => anyhow::bail!("Chip not supported in Wokwi. Refer to https://docs.wokwi.com/guides/esp32#simulation-features"),
+                _ => unreachable!(),
             }
         }
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,9 +67,21 @@ async fn wokwi_task(
 ) -> Result<()> {
     let server = TcpListener::bind(("127.0.0.1", PORT)).await?;
 
+    let project_id = match opts.id.clone() {
+        Some(id) => id,
+        None => {
+            match opts.chip {
+                Chip::Esp32 => "331362827438654036".to_string(),
+                Chip::Esp32s2 => "332188085821375060".to_string(),
+                Chip::Esp32c3 => "332188235906155092".to_string(),
+                _ => anyhow::bail!("Chip not supported in Wokwi. Refer to https://docs.wokwi.com/guides/esp32#simulation-features"),
+            }
+        }
+    };
+
     let mut url = format!(
         "https://wokwi.com/_alpha/wembed/{}?partner=espressif&port={}&data=demo",
-        opts.id.clone().unwrap_or("327866241856307794".to_owned()),
+        project_id,
         PORT
     );
     opts.host.as_ref().map(|h| url.push_str(&format!("&_host={}",h)));


### PR DESCRIPTION
- If no project id argument is passed, use a default project which contains the specified chip. 
- Add an initial check to see if the chip is supported in Wokwi (currently `esp32s3` and `esp8266` are not supported)
- Update `cargo.lock`
- Fix cargo clippy warnings

As you know, my Rust knowledge is very limited so don't hesitate to comment on my changes :)