### PR TITLE
Add CI to generate release packages

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,46 @@
+name: Package
+
+on:
+  workflow_call:
+    inputs:
+      runs_on:
+        required: true
+        type: string
+      target:
+        required: true
+        type: string
+      extension:
+        default: ""
+        type: string
+
+jobs:
+  build:
+    name: Build static binaries
+    runs-on: ${{ inputs.runs_on }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ inputs.target }}
+
+      - uses: Swatinem/rust-cache@v1
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --all --target ${{ inputs.target }}
+
+      - uses: papeloto/action-zip@v1
+        with:
+          files: target/${{ inputs.target }}/release/wokwi-server${{ inputs.extension }}
+          recursive: true
+          dest: wokwi-server-${{ inputs.target }}.zip
+
+      - uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: wokwi-server-${{ inputs.target }}.zip
+          tag: ${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  # Linux
+
+  x86_64-unknown-linux-gnu:
+    uses: ./.github/workflows/package.yml
+    with:
+      runs_on: ubuntu-latest
+      target: x86_64-unknown-linux-gnu
+
+  x86_64-unknown-linux-musl:
+    uses: ./.github/workflows/package.yml
+    with:
+      runs_on: ubuntu-latest
+      target: x86_64-unknown-linux-musl
+
+  # macOS
+
+  aarch64-apple-darwin:
+    uses: ./.github/workflows/package.yml
+    with:
+      runs_on: macos-latest
+      target: aarch64-apple-darwin
+
+  x86_64-apple-darwin:
+    uses: ./.github/workflows/package.yml
+    with:
+      runs_on: macos-latest
+      target: x86_64-apple-darwin
+
+  # Windows
+
+  x86_64-pc-windows-gnu:
+    uses: ./.github/workflows/package.yml
+    with:
+      runs_on: windows-latest
+      target: x86_64-pc-windows-gnu
+      extension: .exe
+
+  x86_64-pc-windows-msvc:
+    uses: ./.github/workflows/package.yml
+    with:
+      runs_on: windows-latest
+      target: x86_64-pc-windows-msvc
+      extension: .exe


### PR DESCRIPTION
Hello! 
Small PR with CI to generate release package! It would be very handy to have this CI and a release so we can download the packages instead of building it from source in devcontainers (also really useful for esp-idf containers where we don't have cargo installed)