### PR TITLE
Report errors in case listen on port 9012 fails

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use anyhow::Result;
 use bytes::{Buf, BytesMut};
 use espflash::elf::ElfFirmwareImage;
@@ -71,8 +72,13 @@ async fn main() -> Result<(), anyhow::Error> {
             },
             task = set.join_next() => {
                 match task {
-                    Some(Err(e)) => {
-                        println!("Task failed: {:?}", e);
+                    Some(Err(join_error)) => {
+                        println!("Task failed: {:?}", join_error);
+                        set.shutdown().await;
+                        break;
+                    }
+                    Some(Ok(Err(task_error))) => {
+                        println!("Task failed: {:?}", task_error);
                         set.shutdown().await;
                         break;
                     }
@@ -90,7 +96,9 @@ async fn wokwi_task(
     mut send: Sender<String>,
     mut recv: Receiver<GdbInstruction>,
 ) -> Result<()> {
-    let server = TcpListener::bind(("127.0.0.1", PORT)).await?;
+    let server = TcpListener::bind(("127.0.0.1", PORT))
+        .await
+        .with_context(|| format!("Failed to listen on 127.0.0.1:{}", PORT))?;
 
     let project_id = match opts.id.clone() {
         Some(id) => id,
@@ -152,7 +160,9 @@ async fn process(
     };
 
     // TODO allow setting flash params, or take from bootloader?
-    let image = opts.chip.get_flash_image(&firmware, b, p, None, None, None, None, None)?;
+    let image = opts
+        .chip
+        .get_flash_image(&firmware, b, p, None, None, None, None, None)?;
     let parts: Vec<_> = image.flash_segments().collect();
 
     let bootloader = &parts[0];


### PR DESCRIPTION
I was using https://github.com/esp-rs/esp-idf-template with devcontainers enabled to try wokwi. It turns out the devcontainer (helpfully!) tries to listen on port 9012 and redirect it. The sideffect from this though is that if trying to run wowki-server on the host rather than the VM, I get a "Address already in use".

Unforunately it seems that he current task code returns `Ok(Err(_))` in case of await errors and NOT the expected `Err(_)` so the program would just silently stop for me which was annoying to debug. Note that `task` is of type `Option<Result<Result<(), Error>, JoinError>>` (!). So we need to treat both JoinError AND the underlying result/error.

I made the following changes:
  - also consider Ok(Err(...)) a potential return.
  - Added a context to the listen error code:telling me what it listens on is more useful than just saying "address in use, code 98".

After the change, I get:

```bash
 ❯ cargo run -- --chip esp32c3 ../../rust_development/c3/hello-world/target/riscv32imc-esp-espidf/debug/hello-world
    Finished dev [unoptimized + debuginfo] target(s) in 0.07s
     Running `target/debug/wokwi-server --chip esp32c3 ../../rust_development/c3/hello-world/target/riscv32imc-esp-espidf/debug/hello-world`
Task failed: Failed to listen on 127.0.0.1:9012

Caused by:
    Address already in use (os error 98)
```

without it, it would just silently finish.