### PR TITLE
Add troubleshooting section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,11 @@ Wokwi exposes a GDB stub which this tool exposes via a TCP connection, see the f
     "valuesFormatting": "parseText"
 }
 ```
+
+## Troubleshooting
+
+If Wokwi doesn't progress past "Connecting to ws://localhost:9012..." in the browser:
+
+- It is likely that your browser is blocking mixed content (Safari and Orion both do this)
+- You may override your default browser using the `$BROWSER` environment variable.
+  - If using `wokwi-server` as a cargo runner, set this in `.cargo/config.toml`


### PR DESCRIPTION
The new troubleshooting section contains one entry.

I encountered issues using Safari as my default browser, as it blocks the use of mixed content (even for localhost). Pasting the link into Google Chrome fixes this problem.

 `opener::open_browser` permits overriding the default browser using the `$BROWSER` environment variable. This would have been helpful for me an hour ago, so i think it belongs in the README.